### PR TITLE
Decouple input and output dimensions when writing

### DIFF
--- a/src/NetTopologySuite.IO.TinyWKB/TinyWkbWriter.CoordinateSequenceWriter.cs
+++ b/src/NetTopologySuite.IO.TinyWKB/TinyWkbWriter.CoordinateSequenceWriter.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Buffers;
 using System.IO;
+
+using NetTopologySuite.DataStructures;
 using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.IO
@@ -9,116 +10,116 @@ namespace NetTopologySuite.IO
     {
         private class CoordinateSequenceWriter
         {
+            private static readonly Ordinate[] OrdinatesXY = new Ordinate[] { Ordinate.X, Ordinate.Y };
+
+            private static readonly Ordinate[] OrdinatesXYZ = new Ordinate[] { Ordinate.X, Ordinate.Y, Ordinate.Z };
+
+            private static readonly Ordinate[] OrdinatesXYM = new Ordinate[] { Ordinate.X, Ordinate.Y, Ordinate.M };
+
+            private static readonly Ordinate[] OrdinatesXYZM = new Ordinate[] { Ordinate.X, Ordinate.Y, Ordinate.Z, Ordinate.M };
+
             private readonly long[] _prevCoordinate;
+
+            private readonly double[] _scales;
 
             public CoordinateSequenceWriter(TinyWkbHeader header)
             {
                 if (!header.HasExtendedPrecisionInformation || !(header.HasZ | header.HasM))
                 {
-                    Scales = new[] { header.ScaleX(), header.ScaleY() };
-                    Dimension = 2;
+                    _scales = new[] { header.ScaleX(), header.ScaleY() };
+                    OutputOrdinates = OrdinatesXY;
                 }
                 else if (header.HasZ && !header.HasM)
                 {
-                    Scales = new[] { header.ScaleX(), header.ScaleY(), header.ScaleZ() };
-                    Dimension = 3;
+                    _scales = new[] { header.ScaleX(), header.ScaleY(), header.ScaleZ() };
+                    OutputOrdinates = OrdinatesXYZ;
                 }
                 else if (!header.HasZ && header.HasM)
                 {
-                    Scales = new[] { header.ScaleX(), header.ScaleY(), header.ScaleM() };
-                    Dimension = 3;
-                    Measures = 1;
+                    _scales = new[] { header.ScaleX(), header.ScaleY(), header.ScaleM() };
+                    OutputOrdinates = OrdinatesXYM;
                 }
                 else
                 {
-                    Scales = new[] { header.ScaleX(), header.ScaleY(), header.ScaleZ(), header.ScaleM() };
-                    Dimension = 4;
-                    Measures = 1;
+                    _scales = new[] { header.ScaleX(), header.ScaleY(), header.ScaleZ(), header.ScaleM() };
+                    OutputOrdinates = OrdinatesXYZM;
                 }
 
-                _prevCoordinate = new long[Dimension];
+                _prevCoordinate = new long[OutputOrdinates.Length];
             }
 
-            /// <summary>
-            /// Gets the number of dimensions to write
-            /// </summary>
-            public int Dimension { get; }
+            public Ordinate[] OutputOrdinates { get; }
 
-            /// <summary>
-            /// Gets the number of measure values to write
-            /// </summary>
-            public int Measures { get; }
-
-            /// <summary>
-            /// Gets a vector containing the scale factors for each ordinate
-            /// </summary>
-            public double[] Scales { get; }
-
-            public void Write(BinaryWriter writer, CoordinateSequence sequence, int omit, int coordinatesRequired)
+            public void Write(BinaryWriter writer, CoordinateSequence sequence, int coordinatesRequired, bool skipLastCoordinate = false, bool writeCount = false)
             {
                 if (sequence == null || sequence.Count == 0)
                     return;
 
-                int count = sequence.Count - omit;
-                long[] prevCoordinate = _prevCoordinate;
-                Span<long> encCoordinate = stackalloc long[Dimension];
+                int inputCount = sequence.Count - (skipLastCoordinate ? 1 : 0);
+                int outputCount = Math.Max(inputCount, coordinatesRequired);
 
-                // Get an array of longs to store ordinate data in
-                long[] ordinatesToWrite = ArrayPool<long>.Shared.Rent(count * Dimension);
-                int coordinatesToWrite = 0;
-                for (int i = 0; i < count; i++)
+                if (writeCount)
+                    writer.Write(VarintBitConverter.GetVarintBytes((uint)outputCount));
+
+                ReadOnlySpan<double> scales = _scales;
+                Span<long> prevCoordinate = _prevCoordinate;
+
+                Span<int> ordinateIndexes = stackalloc int[OutputOrdinates.Length];
+                for (int i = 0; i < OutputOrdinates.Length; i++)
                 {
-                    // Assume we don't need to write the coordinate
-                    bool write = false;
+                    sequence.TryGetOrdinateIndex(OutputOrdinates[i], out ordinateIndexes[i]);
+                }
 
+                for (int i = 0; i < inputCount; i++)
+                {
                     // Encode ordinate values
-                    for (int dim = 0; dim < Dimension; dim++)
+                    for (int dim = 0; dim < ordinateIndexes.Length; dim++)
                     {
-                        encCoordinate[dim] = EncodeOrdinate(sequence.GetOrdinate(i, dim), Scales[dim], ref prevCoordinate[dim]);
-                        write |= encCoordinate[dim] != 0;
-                    }
-
-                    // This coordinate is different from the last.
-                    if (write)
-                    {
-                        for (int dim = 0; dim < Dimension; dim++)
-                            ordinatesToWrite[coordinatesToWrite * Dimension + dim] = encCoordinate[dim];
-                        coordinatesToWrite++;
+                        double val = ordinateIndexes[dim] == -1
+                            ? double.NaN
+                            : sequence.GetOrdinate(i, ordinateIndexes[dim]);
+                        long enc = EncodeOrdinate(val, scales[dim], ref prevCoordinate[dim]);
+                        writer.Write(VarintBitConverter.GetVarintBytes(enc));
                     }
                 }
 
-                // Write 0's for required coordinates
-                if (coordinatesToWrite < coordinatesRequired)
-                    coordinatesToWrite = coordinatesRequired;
+                if (inputCount < outputCount)
+                {
+                    // Write 0's for required coordinates: first coordinate after the input is a
+                    // special-case to reset the "prev" markers to 0.
+                    for (int dim = 0; dim < prevCoordinate.Length; dim++)
+                    {
+                        writer.Write(VarintBitConverter.GetVarintBytes(-prevCoordinate[dim]));
+                    }
 
-                // If we have more than one coordinate to write, report that!
-                if (coordinatesToWrite > 1)
-                    writer.Write(VarintBitConverter.GetVarintBytes((uint)coordinatesToWrite));
+                    prevCoordinate.Clear();
 
-                // Write ordinate values
-                coordinatesToWrite *= Dimension;
-                for(int i = 0; i < coordinatesToWrite; i++)
-                    writer.Write(VarintBitConverter.GetVarintBytes(ordinatesToWrite[i]));
-
-                // return ordinate longs array
-                ArrayPool<long>.Shared.Return(ordinatesToWrite);
+                    // remaining values to write (if any) are all 0, so just write that however many
+                    // times we need to.  it shouldn't be more than 4.
+                    int zeroCount = (outputCount - inputCount - 1) * prevCoordinate.Length;
+                    for (int i = 0; i < zeroCount; i++)
+                    {
+                        writer.Write((byte)0);
+                    }
+                }
             }
 
-            public static long EncodeOrdinate(double value, double scale, ref long lastScaledValue)
+            public void WriteIntervals(BinaryWriter writer, ReadOnlySpan<Interval> intervals)
+            {
+                for (int i = 0; i < intervals.Length; i++)
+                {
+                    long prev = 0;
+                    writer.Write(VarintBitConverter.GetVarintBytes(EncodeOrdinate(intervals[i].Min, _scales[i], ref prev)));
+                    writer.Write(VarintBitConverter.GetVarintBytes(EncodeOrdinate(intervals[i].Max, _scales[i], ref prev)));
+                }
+            }
+
+            private static long EncodeOrdinate(double value, double scale, ref long lastScaledValue)
             {
                 long lngValue = (long)Math.Round(value * scale, 0, MidpointRounding.AwayFromZero);
                 long valueEnc = lngValue - lastScaledValue;
                 lastScaledValue = lngValue;
                 return valueEnc;
-            }
-
-            /// <summary>
-            /// Method to initialize the previous coordinate
-            /// </summary>
-            public void InitPrevCoordinate()
-            {
-                for (int i = 0; i < Dimension; i++)
-                    _prevCoordinate[i] = 0;
             }
         }
     }

--- a/src/NetTopologySuite.IO.TinyWKB/TinyWkbWriter.cs
+++ b/src/NetTopologySuite.IO.TinyWKB/TinyWkbWriter.cs
@@ -274,7 +274,7 @@ namespace NetTopologySuite.IO
         {
             if (!EmitBoundingBox) return;
 
-            var minMaxFilter = new MinMaxFilter(csWriter.OutputOrdinates);
+            var minMaxFilter = new MinMaxFilter(csWriter.Dimension);
             geometry.Apply(minMaxFilter);
 
             csWriter.WriteIntervals(writer, minMaxFilter.Intervals);
@@ -356,13 +356,11 @@ namespace NetTopologySuite.IO
 
         private class MinMaxFilter : ICoordinateSequenceFilter
         {
-            private readonly Ordinate[] _outputOrdinates;
             private readonly Interval[] _intervals;
 
-            public MinMaxFilter(Ordinate[] outputOrdinates)
+            public MinMaxFilter(int dimension)
             {
-                _outputOrdinates = outputOrdinates;
-                _intervals = new Interval[_outputOrdinates.Length];
+                _intervals = new Interval[dimension];
                 for (int i = 0; i < _intervals.Length; i++)
                     _intervals[i] = Interval.Create();
             }
@@ -375,9 +373,9 @@ namespace NetTopologySuite.IO
 
             public void Filter(CoordinateSequence seq, int i)
             {
-                for (int dim = 0; dim < _outputOrdinates.Length; dim++)
+                for (int dim = 0; dim < _intervals.Length; dim++)
                 {
-                    double val = seq.GetOrdinate(i, _outputOrdinates[dim]);
+                    double val = seq.GetOrdinate(i, dim);
                     _intervals[dim] = _intervals[dim].ExpandedByValue(val);
                 }
             }

--- a/src/NetTopologySuite.IO.TinyWKB/TinyWkbWriter.cs
+++ b/src/NetTopologySuite.IO.TinyWKB/TinyWkbWriter.cs
@@ -210,22 +210,22 @@ namespace NetTopologySuite.IO
         private void WritePoint(BinaryWriter writer, CoordinateSequenceWriter csWriter, Point point)
         {
             // We don't write bounding boxes for points. Period.
-            csWriter.Write(writer, point.CoordinateSequence, 1);
+            csWriter.Write(writer, point.CoordinateSequence);
         }
 
         private void WriteLineString(BinaryWriter writer, CoordinateSequenceWriter csWriter, LineString lineString)
         {
             WriteBoundingBox(writer, csWriter, lineString);
-            csWriter.Write(writer, lineString.CoordinateSequence, 2, writeCount: true);
+            csWriter.Write(writer, lineString.CoordinateSequence, writeCount: true);
         }
 
         private void WritePolygon(BinaryWriter writer, CoordinateSequenceWriter csWriter, Polygon polygon, bool omitBoundingBox = false)
         {
             if (!omitBoundingBox) WriteBoundingBox(writer, csWriter, polygon);
             writer.Write(VarintBitConverter.GetVarintBytes((uint)(1 + polygon.NumInteriorRings)));
-            csWriter.Write(writer, polygon.Shell.CoordinateSequence, 3, skipLastCoordinate: true, writeCount: true);
+            csWriter.Write(writer, polygon.Shell.CoordinateSequence, skipLastCoordinate: true, writeCount: true);
             for (int i = 0; i < polygon.NumInteriorRings; i++)
-                csWriter.Write(writer, polygon.GetInteriorRingN(i).CoordinateSequence, 3, skipLastCoordinate: true, writeCount: true);
+                csWriter.Write(writer, polygon.GetInteriorRingN(i).CoordinateSequence, skipLastCoordinate: true, writeCount: true);
         }
 
         private void WriteMultiPoint(BinaryWriter writer, CoordinateSequenceWriter csWriter, MultiPoint multiPoint, long[] idList)
@@ -234,7 +234,7 @@ namespace NetTopologySuite.IO
             writer.Write(VarintBitConverter.GetVarintBytes((uint)multiPoint.NumGeometries));
             WriteIdList(writer, multiPoint, idList);
             for (int i = 0; i < multiPoint.NumGeometries; i++)
-                csWriter.Write(writer, ((Point)multiPoint.GetGeometryN(i)).CoordinateSequence, 1);
+                csWriter.Write(writer, ((Point)multiPoint.GetGeometryN(i)).CoordinateSequence);
         }
 
         private void WriteMultiLineString(BinaryWriter writer, CoordinateSequenceWriter csWriter,
@@ -244,7 +244,7 @@ namespace NetTopologySuite.IO
             writer.Write(VarintBitConverter.GetVarintBytes((uint)multiLineString.NumGeometries));
             WriteIdList(writer, multiLineString, idList);
             for (int i = 0; i < multiLineString.NumGeometries; i++)
-                csWriter.Write(writer, ((LineString)multiLineString.GetGeometryN(i)).CoordinateSequence, 2, writeCount: true);
+                csWriter.Write(writer, ((LineString)multiLineString.GetGeometryN(i)).CoordinateSequence, writeCount: true);
         }
 
         private void WriteMultiPolygon(BinaryWriter writer, CoordinateSequenceWriter csWriter,

--- a/test/NetTopologySuite.IO.TinyWKB.Test/CsFactoryType.cs
+++ b/test/NetTopologySuite.IO.TinyWKB.Test/CsFactoryType.cs
@@ -1,0 +1,10 @@
+namespace NetTopologySuite.IO.Test
+{
+    public enum CsFactoryType
+    {
+        Array,
+        PackedDouble,
+        PackedFloat,
+        DotSpatialAffine
+    }
+}

--- a/test/NetTopologySuite.IO.TinyWKB.Test/RoundTripWkxTests.cs
+++ b/test/NetTopologySuite.IO.TinyWKB.Test/RoundTripWkxTests.cs
@@ -1,0 +1,229 @@
+using System;
+using System.ComponentModel.Design;
+using System.Linq;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
+using NUnit.Framework;
+
+namespace NetTopologySuite.IO.Test
+{
+    [TestFixture(CsFactoryType.Array)]
+    [TestFixture(CsFactoryType.PackedFloat)]
+    [TestFixture(CsFactoryType.PackedDouble)]
+    [TestFixture(CsFactoryType.DotSpatialAffine)]
+    public class RoundTripWkxTests
+    {
+        private readonly NtsGeometryServices _ntsGeometryServices;
+        private readonly WKBReader _wkbReader;
+        private readonly WKTReader _wktReader;
+
+        public RoundTripWkxTests(CsFactoryType csFactoryType)
+        {
+            var pm = new PrecisionModel();
+            int srid = 126;
+            CoordinateSequenceFactory csFactory;
+            switch (csFactoryType)
+            {
+                default:
+                case CsFactoryType.Array:
+                    csFactory = CoordinateArraySequenceFactory.Instance;
+                    break;
+                case CsFactoryType.PackedFloat:
+                    csFactory = PackedCoordinateSequenceFactory.FloatFactory;
+                    break;
+                case CsFactoryType.PackedDouble:
+                    csFactory = PackedCoordinateSequenceFactory.DoubleFactory;
+                    break;
+                case CsFactoryType.DotSpatialAffine:
+                    csFactory = DotSpatialAffineCoordinateSequenceFactory.Instance;
+                    break;
+
+            }
+
+            _ntsGeometryServices = new NtsGeometryServices(csFactory, pm, srid);
+            _wkbReader = new WKBReader(_ntsGeometryServices);
+            _wktReader = new WKTReader(_ntsGeometryServices.CreateGeometryFactory());
+
+
+        }
+
+        [TestCase("POINT (10 10)")]
+        [TestCase("LINESTRING (10 10, 15 10, 20 15, 25 20)")]
+        [TestCase("POLYGON ((10 10, 15 10, 15 15, 10 15, 10 10))")]
+        [TestCase("POLYGON ((10 10, 15 10, 15 15, 10 15, 10 10), (11 11, 11 14, 14 14, 14 11, 11 11))")]
+        public void TestWkx(string wktOrWkb)
+        {
+
+            var geomS = wktOrWkb.StartsWith("0x")
+                ? _wkbReader.Read(WKBReader.HexToBytes(wktOrWkb.Substring(2)))
+                : _wktReader.Read(wktOrWkb);
+
+            Test2D(geomS);
+            Test2DM(geomS);
+            Test3D(geomS);
+            Test3DM(geomS);
+        }
+
+        private void Test2D(Geometry geomS)
+        {
+            var twkbWriter = new TinyWkbWriter();
+            byte[] bytes = twkbWriter.Write(geomS);
+            var twkbReader = new TinyWkbReader(_ntsGeometryServices.CreateGeometryFactory());
+            var geomD = twkbReader.Read(bytes);
+
+            Check(geomS, geomD, Ordinates.XY);
+        }
+
+        private void Test2DM(Geometry geomS)
+        {
+            if (CoordinateArrays.Measures(geomS.Coordinates) == 0)
+                geomS = AddOrdinates(geomS, Ordinate.M);
+
+            var twkbWriter = new TinyWkbWriter(emitM: true);
+            byte[] bytes = twkbWriter.Write(geomS);
+            var twkbReader = new TinyWkbReader(_ntsGeometryServices.CreateGeometryFactory());
+            var geomD = twkbReader.Read(bytes);
+
+            Check(geomS, geomD, Ordinates.XYM);
+        }
+
+        private void Test3D(Geometry geomS)
+        {
+            if (CoordinateArrays.Measures(geomS.Coordinates) == 0)
+                geomS = AddOrdinates(geomS, Ordinate.Z);
+
+            var twkbWriter = new TinyWkbWriter(emitZ: true);
+            byte[] bytes = twkbWriter.Write(geomS);
+            var twkbReader = new TinyWkbReader(_ntsGeometryServices.CreateGeometryFactory());
+            var geomD = twkbReader.Read(bytes);
+
+            Check(geomS, geomD, Ordinates.XYZ);
+        }
+        private void Test3DM(Geometry geomS)
+        {
+            if (CoordinateArrays.Measures(geomS.Coordinates) == 0)
+                geomS = AddOrdinates(geomS, Ordinate.Z, Ordinate.M);
+
+            var twkbWriter = new TinyWkbWriter(emitZ: true, emitM:true);
+            byte[] bytes = twkbWriter.Write(geomS);
+            var twkbReader = new TinyWkbReader(_ntsGeometryServices.CreateGeometryFactory());
+            var geomD = twkbReader.Read(bytes);
+
+            Check(geomS, geomD, Ordinates.XYZ);
+        }
+
+        private Geometry AddOrdinates(Geometry geom, params Ordinate[] ordinates)
+        {
+            var geoms = new Geometry[geom.NumGeometries];
+            for (int i = 0; i < geom.NumGeometries; i++)
+            {
+                var geomI = geom.GetGeometryN(i);
+                switch (geomI.OgcGeometryType)
+                {
+                    case OgcGeometryType.Point:
+                        geoms[i] = geom.Factory.CreatePoint(AddOrdinates(((Point) geomI).CoordinateSequence, 1, ordinates));
+                        break;
+                    case OgcGeometryType.LineString:
+                        geoms[i] = geom.Factory.CreateLineString(AddOrdinates(((LineString)geomI).CoordinateSequence, 1, ordinates));
+                        break;
+                    case OgcGeometryType.Polygon:
+                        int offset = 1;
+                        var poly = (Polygon) geomI;
+                        var shell = geom.Factory.CreateLinearRing(AddOrdinates(poly.ExteriorRing.CoordinateSequence, offset, ordinates));
+                        offset += shell.NumPoints;
+                        var holes = new LinearRing[poly.NumInteriorRings];
+                        for (int j = 0; j < poly.NumInteriorRings; j++)
+                        {
+                            holes[j] = geom.Factory.CreateLinearRing(AddOrdinates(poly.GetInteriorRingN(j).CoordinateSequence, offset, ordinates));
+                            offset += shell.NumPoints;
+                        }
+                        geoms[i] = geom.Factory.CreatePolygon(shell, holes);
+                        break;
+                }
+            }
+
+            if (geoms.Length == 1)
+                return geoms[0];
+            return geom.Factory.BuildGeometry(geoms);
+        }
+
+        private CoordinateSequence AddOrdinates(CoordinateSequence sequence, int offset, params Ordinate[] ordinates)
+        {
+            if (ordinates.Length == 0)
+                return sequence;
+
+            int measures = ordinates.Contains(Ordinate.M) ? 1 : 0;
+            var res = _ntsGeometryServices.DefaultCoordinateSequenceFactory.Create(sequence.Count,
+                sequence.Dimension + ordinates.Length, measures);
+
+            for (int i = 0; i < sequence.Count; i++)
+            {
+                res.SetX(i, sequence.GetX(i));
+                res.SetY(i, sequence.GetY(i));
+                for (int j = 0; j < ordinates.Length; j++)
+                    res.SetOrdinate(i, ordinates[j], (100d * offset+i) + (double)ordinates[j]);
+            }
+
+            return res;
+        }
+
+        private void Check(Geometry geomS, Geometry geomD, Ordinates ordinates)
+        {
+            Assert.That(geomD.OgcGeometryType, Is.EqualTo(geomS.OgcGeometryType));
+            Assert.That(geomD.NumGeometries, Is.EqualTo(geomS.NumGeometries));
+
+            for (int i = 0; i < geomS.NumGeometries; i++)
+            {
+                var geomSi = geomS.GetGeometryN(i);
+                var geomDi = geomD.GetGeometryN(i);
+                Assert.That(geomDi.OgcGeometryType, Is.EqualTo(geomSi.OgcGeometryType));
+                switch (geomSi.OgcGeometryType)
+                {
+                    case OgcGeometryType.Point:
+                        CheckPoint((Point) geomSi, (Point) geomDi, ordinates);
+                        break;
+                    case OgcGeometryType.LineString:
+                        CheckLineString((LineString)geomSi, (LineString)geomDi, ordinates);
+                        break;
+                    case OgcGeometryType.Polygon:
+                        CheckPolygon((Polygon)geomSi, (Polygon)geomDi, ordinates);
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+        }
+
+        private void CheckPolygon(Polygon geomSi, Polygon geomDi, Ordinates ordinates)
+        {
+            CheckLineString(geomSi.ExteriorRing, geomDi.ExteriorRing, ordinates);
+            for (int i = 0; i < geomSi.NumInteriorRings; i++)
+                CheckLineString(geomSi.GetInteriorRingN(i), geomDi.GetInteriorRingN(i), ordinates);
+        }
+
+        private void CheckLineString(LineString geomSi, LineString geomDi, Ordinates ordinates)
+        {
+            CheckCoordinateSequence(geomSi.CoordinateSequence, geomDi.CoordinateSequence, ordinates);
+        }
+
+        private void CheckPoint(Point geomSi, Point geomDi, Ordinates ordinates)
+        {
+            CheckCoordinateSequence(geomSi.CoordinateSequence, geomDi.CoordinateSequence, ordinates);
+        }
+
+        private void CheckCoordinateSequence(CoordinateSequence csSi, CoordinateSequence csDi, Ordinates ordinates)
+        {
+            Assert.That(csSi.Count, Is.EqualTo(csDi.Count));
+            for (int i = 0; i < csSi.Count; i++)
+            {
+                Assert.That(csSi.GetX(i), Is.EqualTo(csDi.GetX(i)).Within(1E-5));
+                Assert.That(csSi.GetY(i), Is.EqualTo(csDi.GetY(i)).Within(1E-5));
+                if ((ordinates & Ordinates.Z) == Ordinates.Z)
+                    Assert.That(csSi.GetX(i), Is.EqualTo(csDi.GetX(i)).Within(1E-5));
+                if ((ordinates & Ordinates.M) == Ordinates.M)
+                    Assert.That(csSi.GetX(i), Is.EqualTo(csDi.GetX(i)).Within(1E-5));
+
+            }
+        }
+    }
+}

--- a/test/NetTopologySuite.IO.TinyWKB.Test/TinyWkbReaderTest.cs
+++ b/test/NetTopologySuite.IO.TinyWKB.Test/TinyWkbReaderTest.cs
@@ -19,8 +19,7 @@ namespace NetTopologySuite.IO.Test
 
         [TestCase("01000204", OgcGeometryType.Point)]
         [TestCase("02000202020808", OgcGeometryType.LineString)]
-        //This Polygon has repeated points, which are discarded.
-        //[TestCase("03031b000400040205000004000004030000030500000002020000010100", OgcGeometryType.Polygon)]
+        [TestCase("03031b000400040205000004000004030000030500000002020000010100", OgcGeometryType.Polygon)]
         [TestCase("0303170004000402040400000403000003040002020000010100", OgcGeometryType.Polygon)]
         [TestCase("04070b0004020402000200020404", OgcGeometryType.MultiPoint)]
         [TestCase("020309020802080202020808", OgcGeometryType.LineString)]


### PR DESCRIPTION
This ensures that, e.g., XY and XYZ will look the same when written as XYM, as well as addressing a few other comments that I put on 74ad417.